### PR TITLE
Fix .lock! on ActiveRecord model objects

### DIFF
--- a/lib/obfuscate_id.rb
+++ b/lib/obfuscate_id.rb
@@ -72,7 +72,7 @@ module ObfuscateId
 
       fresh_object =
         if options && options[:lock]
-          self.class.unscoped { self.class.lock(options[:lock]).find(id, options) }
+          self.class.unscoped { self.class.lock(options[:lock]).find(id) }
         else
           self.class.unscoped { self.class.find(id, options) }
         end


### PR DESCRIPTION
When updating Payable from Rails 3 or Rails 6, `.lock!` on model objects breaks.

In Rails 3, `self.class.lock` returns a collection of class `ActiveRecord::Relation`, for which the `.find` method is overwritten in this package.

However in Rails 4+, `self.class.lock` returns a collection of class `Project::ActiveRecord_Relation`, which has not been overwritten, and which expects all arguments passed to it by its `.find` method to be object ids.
